### PR TITLE
replaced _GLIBCXX_USE_NOEXCEPT with noexcept

### DIFF
--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -109,7 +109,7 @@ typedef enum
 class CancelException : public std::exception
 {
 public:
-    const char *what() const _GLIBCXX_USE_NOEXCEPT
+    const char *what() const noexcept
     {
         return "Operation was cancelled by user";
     }


### PR DESCRIPTION
Since the project is already configured for c++14, it is I think safe to use noexcept. 
Then it compiles with Visual Studio as well