### PR TITLE
Machine coordinate moves (G53) no longer affected by heightmap

### DIFF
--- a/src/frmmain_heightmap.cpp
+++ b/src/frmmain_heightmap.cpp
@@ -631,6 +631,7 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
             QString lastCode;
             bool isLinearMove;
             bool hasCommand;
+            bool isMachineCoords;
 
             m_programLoading = true;
             for (int i = 0; i < m_programModel.rowCount() - 1; i++) {
@@ -638,6 +639,7 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
                 line = m_programModel.data().at(i).line;
                 isLinearMove = false;
                 hasCommand = false;
+                isMachineCoords = false;
 
                 if (line < 0 || line == lastCommandIndex || lastSegmentIndex == list->count() - 1) {
                     item.command = command;
@@ -668,6 +670,10 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
                                     newCommand.append(arg);
                                 }
 
+                                if (codeNum == 53.0f) {
+                                    isMachineCoords = true;
+                                }
+
                                 hasCommand = true;                  // Command has 'G'
                             } else {
                                 if (m.contains(codeChar))
@@ -680,7 +686,7 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
                     // Find first linesegment by command index
                     for (int j = lastSegmentIndex; j < list->count(); j++) {
                         if (list->at(j)->getLineNumber() == line) {
-                            if (!qIsNaN(list->at(j)->getEnd().length()) && (isLinearMove || (!hasCommand && !lastCode.isEmpty()))) {
+                            if (!qIsNaN(list->at(j)->getEnd().length()) && ((isLinearMove && !isMachineCoords) || (!hasCommand && !lastCode.isEmpty()))) {
                                 // Create new commands for each linesegment with given command index
                                 while ((j < list->count()) && (list->at(j)->getLineNumber() == line)) {
 


### PR DESCRIPTION
Programs containing machine coordinate moves (G53) are currently modified by the heightmap in a manner which causes undesired behaviour.

As an example, consider this sequence generated by pcb2gcode for a tool retract at the end of a job:

```
G01 X39.24346 Y-4.06418
G04 P0 ( dwell for no time -- G64 should not smooth over this point )
G53 G00 Z-1.000000 ( retract )
```

When a heightmap is applied this is converted to:

```
G01X39.243Y-4.064Z-0.044
G04 P0 ( dwell for no time -- G64 should not smooth over this point )
G53G00X39.243Y-4.064Z-0.994
```

This now attempts to move to `X39.243 Y-4.064` in machine coordinates which results in either a machine halt or an unexpected move.

This PR changes the behaviour such that G53 commands are passed unmodified restoring the original behaviour.

```
G01X39.243Y-4.064Z-0.044
G04 P0 ( dwell for no time -- G64 should not smooth over this point )
G53 G00 Z-1.000000 ( retract )
```