### PR TITLE
Make 'Interface' selection persistent.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,6 +19,7 @@ System requirements for running "Candle2":
 Build requirements:
 ------------------
 Windows: Qt 5.15.2 with MinGW/GCC compiler
+
 Linux: QT 5.12.2 with GCC
 
 Downloads:

--- a/src/frmmain_settings.cpp
+++ b/src/frmmain_settings.cpp
@@ -165,6 +165,10 @@ void frmMain::loadSettings()
     m_settings->setVisualizerText(QColor(set.value("VisualizerText", QColor(0, 0, 0)).toString()));
     m_settings->setTool(QColor(set.value("Tool", QColor(255, 153, 0)).toString()));
 
+    const auto interface = set.value("interface");
+    if (interface.isValid())
+        ui->comboInterface->setCurrentText(interface.toString());
+    
     updateRecentFilesMenu();
 
     ui->tblProgram->horizontalHeader()->restoreState(set.value("header", QByteArray()).toByteArray());
@@ -304,6 +308,8 @@ void frmMain::saveSettings()
         list.append(ui->cboCommand->itemText(i));
 
     set.setValue("recentCommands", list);
+
+    set.setValue("interface", ui->comboInterface->currentText());
 }
 
 bool frmMain::saveChanges(bool heightMapMode)


### PR DESCRIPTION
This PR makes Candle remember the 'Interface' setting - on my system, the default is ttyS4, but the correct one is ttyUSB0.

Also adds a missing line break in Readme.md.