### PR TITLE
support multiple machine-specific configurations ("profiles")

### DIFF
--- a/src/candle2.pro
+++ b/src/candle2.pro
@@ -55,6 +55,7 @@ SOURCES += main.cpp\
     parser/pointsegment.cpp \
     tables/gcodetablemodel.cpp \
     tables/heightmaptablemodel.cpp \
+    utils/profiles.cpp \
     widgets/colorpicker.cpp \
     widgets/combobox.cpp \
     widgets/groupbox.cpp \
@@ -96,6 +97,7 @@ HEADERS  += frmmain.h \
     tables/gcodetablemodel.h \
     tables/heightmaptablemodel.h \
     utils/interpolation.h \
+    utils/profiles.h \
     utils/util.h \
     widgets/colorpicker.h \
     widgets/combobox.h \

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -326,6 +326,7 @@ private:
     void jogStep();
     void updateJogTitle();
 
+    QString findConfigPath();
 
     Ui::frmMain *ui;
     GcodeViewParse m_viewParser;
@@ -358,7 +359,7 @@ private:
     frmSettings *m_settings;
     frmAbout m_frmAbout;
 
-    QString m_settingsFileName;
+    QString m_settingsFilePath;
     QString m_programFileName;
     QString m_heightMapFileName;
     QString m_lastFolder;
@@ -457,9 +458,6 @@ private:
 
     // Size of internal GRBL buffer
     static const int GRBL_BUFFERLENGTH = 127;
-
-    // Name of setting file
-    const QString settings_file = "/settings.ini";
 
     QSerialPort m_serialHandWheel;
 };

--- a/src/frmmain_settings.cpp
+++ b/src/frmmain_settings.cpp
@@ -24,7 +24,7 @@
 
 void frmMain::loadSettings()
 {
-    QSettings set(m_settingsFileName, QSettings::IniFormat);
+    QSettings set(m_settingsFilePath, QSettings::IniFormat);
     set.setIniCodec("UTF-8");
 
     m_settingsLoading = true;
@@ -194,7 +194,7 @@ void frmMain::loadSettings()
 
 void frmMain::saveSettings()
 {
-    QSettings set(m_settingsFileName, QSettings::IniFormat);
+    QSettings set(m_settingsFilePath, QSettings::IniFormat);
     set.setIniCodec("UTF-8");
 
     set.setValue("ipaddress", m_settings->IPAddress());

--- a/src/utils/profiles.cpp
+++ b/src/utils/profiles.cpp
@@ -1,0 +1,20 @@
+#include "profiles.h"
+#include <QUrl>
+
+// chosen for backward compatibility with pre-profiles versions, which always stored settings in `settings.ini`
+const QString default_profile_name = "settings";
+
+QStringList getProfileNames() {
+    const QDir configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    const QStringList configFiles = configDir.entryList({"*.ini"}, QDir::Files);
+    QStringList rv;
+    for (QString configFile : configFiles) {
+        rv << QUrl::fromPercentEncoding(configFile.replace(QRegExp("\\.ini$"), "").toUtf8());
+    }
+    return rv;
+}
+
+QString configPathForProfile(QString profile_name) {
+    const QDir configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    return configDir.filePath(QUrl::toPercentEncoding(profile_name) + ".ini");
+}

--- a/src/utils/profiles.h
+++ b/src/utils/profiles.h
@@ -1,0 +1,11 @@
+#ifndef PROFILES_H
+#define PROFILES_H
+#include <QStringList>
+#include <QStandardPaths>
+#include <QDir>
+
+extern const QString default_profile_name;
+QStringList getProfileNames();
+QString configPathForProfile(QString profile_name);
+
+#endif // PROFILES_H


### PR DESCRIPTION
This makes Candle2 usable for driving multiple machines from the same computer, by making separate copies of the entire config file per machine.

By default, nothing will change; the file format is unchanged, and the current configuration is treated as a default profile. If multiple profiles are present at startup, the user is prompted to select one. If the environment variable $CANDLE_PROFILE is present and non-empty, that profile is used without prompting.

Profiles are stored in the app config directory, as urlencode(profilename) + ".ini". (URL-encoding the names allows profiles to be named without regard for the platform's file naming rules.)

There is currently no UI for managing profiles; they may be created by manually copying `settings.ini` to a new file in the same directory, or by setting $CANDLE_PROFILE to a profile that does not yet exist (it will be created with default settings).