### PR TITLE
Fix heightmap probe regex

### DIFF
--- a/src/frmmain_processresponse.cpp
+++ b/src/frmmain_processresponse.cpp
@@ -569,7 +569,7 @@ void frmMain::ProcessGRBL1_1()
                     {
                         // Get probe Z coordinate
                         // "[PRB:0.000,0.000,0.000:0];ok"
-                        QRegExp rx(".*PRB:([^,]*),([^,]*),([^]^:]*)");
+                        QRegExp rx(".*PRB:([^,]*),([^,]*),([^,:\\]]*)");
                         double z = qQNaN();
                         if(rx.indexIn(response) != -1)
                         {
@@ -1405,7 +1405,7 @@ void frmMain::ProcessGRBL_ETH(QString data)
                     {
                         // Get probe Z coordinate
                         // "[PRB:0.000,0.000,0.000:0];ok"
-                        QRegExp rx(".*PRB:([^,]*),([^,]*),([^]^:]*)");
+                        QRegExp rx(".*PRB:([^,]*),([^,]*),([^,:\\]]*)");
                         double z = qQNaN();
                         if(rx.indexIn(response) != -1)
                         {


### PR DESCRIPTION
This will fix heightmap zeroes on machnies that have >3 axis.

In short, some CNC machines have >3axis and thus it responds PRB like this:
```
[PRB:0.000,0.000,0.000,0.000,0.000,0.000:0]
ok
G21G91G38.2Z-30F80 < [PRB:-261.318,-90.941,-16.478,0.000,0.000,0.000:1]
ok
G0Z1 < ok
G38.2Z-2F10 < [PRB:-261.318,-90.941,-16.489,0.000,0.000,0.000:1]
ok
```
To fix this, I made this PR, fixing capturing regex.

See topic https://github.com/Denvi/Candle/issues/589 where it was initially fixed somehow, but using ill-formed regex and not supporting many-axis CNC machines. This PR fixes that issue.