### PR TITLE
Set DTR on Windows builds.

### DIFF
--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -146,7 +146,7 @@ frmMain::frmMain(QWidget *parent) :
     }
 #endif
 #ifndef UNIX
-    ui->cboCommand->setStyleSheet("QComboBox {padding: 2;} QComboBox::drop-down {width: 0; border-style: none;} QComboBox::down-arrow {image: url(noimg);	border-width: 0;}");
+    ui->cboCommand->setStyleSheet("QComboBox {padding: 2;} QComboBox::drop-down {width: 0; border-style: none;} QComboBox::down-arrow {image: url(noimg); border-width: 0;}");
 #endif
 
     m_heightMapMode = false;
@@ -2099,7 +2099,10 @@ void frmMain::on_btnConnect_clicked()
                 ui->txtStatus->setStyleSheet(QString("background-color: palette(button); color: palette(text);"));
 #ifndef WINDOWS
                 SerialIf_Clear();
+#else
+                SerialIf_SetDTR(true);
 #endif
+
                 qDebug() << "Serial OK";
 
                 m_timerRead.start(ReceiveTimerInterval_ms);

--- a/src/interface/SerialInterface.cpp
+++ b/src/interface/SerialInterface.cpp
@@ -101,6 +101,11 @@ void SerialIf_Clear()
     m_serialPort.clear();
 }
 
+bool SerialIf_SetDTR(bool state)
+{
+    return m_serialPort.setDataTerminalReady(state);
+}
+
 QString SerialIf_GetError()
 {
     if(m_Interface == IF_SERIAL)

--- a/src/interface/SerialInterface.h
+++ b/src/interface/SerialInterface.h
@@ -25,6 +25,7 @@ void SerialIf_Close();
 bool SerialIf_IsOpen();
 
 void SerialIf_Clear();
+bool SerialIf_SetDTR(bool state);
 
 QString SerialIf_GetError();
 


### PR DESCRIPTION
Recent grblHAL builds require DTR to be set for USB connections.

Qt does not appear to set DTR automatically on Windows, but does on other platforms.