### PR TITLE
Future-proof code for Qt 6

### DIFF
--- a/src/frmabout.cpp
+++ b/src/frmabout.cpp
@@ -2,6 +2,7 @@
 // Copyright 2015-2016 Hayrullin Denis Ravilevich
 
 #include <QDesktopServices>
+#include <QFile>
 #include "frmabout.h"
 #include "ui_frmabout.h"
 

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -495,9 +495,9 @@ void frmMain::preloadSettings()
     qApp->setStyleSheet(QString(qApp->styleSheet()).replace(QRegExp("font-size:\\s*\\d+"), "font-size: " + set.value("fontSize", "8").toString()));
 
     // Update v-sync in glformat
-    QGLFormat fmt = QGLFormat::defaultFormat();
+    QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
     fmt.setSwapInterval(set.value("vsync", false).toBool() ? 1 : 0);
-    QGLFormat::setDefaultFormat(fmt);
+    QSurfaceFormat::setDefaultFormat(fmt);
 }
 
 void frmMain::updateControlsState()
@@ -1232,7 +1232,7 @@ bool buttonLessThan(StyledToolButton *b1, StyledToolButton *b2)
 
 void frmMain::updateParser()
 {
-    QTime time;
+    QElapsedTimer time;
 
     qDebug() << "Updating parser:" << m_currentModel << m_currentDrawer;
     time.start();
@@ -1513,7 +1513,7 @@ void frmMain::on_cmdFileReset_clicked()
 
     if (!m_heightMapMode)
     {
-        QTime time;
+        QElapsedTimer time;
 
         time.start();
 

--- a/src/frmmain.cpp
+++ b/src/frmmain.cpp
@@ -1878,7 +1878,8 @@ void frmMain::on_grpUserCommands_toggled(bool checked)
 
 int frmMain::getConsoleMinHeight()
 {
-    return ui->grpConsole->height() - ui->grpConsole->contentsRect().height() + ui->spacerConsole->geometry().height() + ui->grpConsole->layout()->margin() * 2 + ui->cboCommand->height();
+    QMargins grpMargins = ui->grpConsole->layout()->contentsMargins();
+    return ui->grpConsole->height() - ui->grpConsole->contentsRect().height() + ui->spacerConsole->geometry().height() + grpMargins.top() + grpMargins.bottom() + ui->cboCommand->height();
 }
 
 void frmMain::onConsoleResized(QSize size)

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -7,7 +7,7 @@
 #include <QtSerialPort/QSerialPort>
 #include <QSettings>
 #include <QTimer>
-#include <QBasicTimer>
+#include <QElapsedTimer>
 #include <QStringList>
 #include <QList>
 #include <QTime>

--- a/src/frmmain.h
+++ b/src/frmmain.h
@@ -395,7 +395,7 @@ private:
     QMenu *m_tableMenu;
     QList<CommandAttributes> m_CommandAttributesList;
     QList<CommandQueue> m_CommandQueueList;
-    QTime m_startTime;
+    QElapsedTimer m_startTime;
 
     SafeQueue<CommandQueue2> mCommandsWait;
     SafeQueue<CommandQueue2> mCommandsSent;

--- a/src/frmmain_heightmap.cpp
+++ b/src/frmmain_heightmap.cpp
@@ -581,7 +581,7 @@ void frmMain::on_chkHeightMapUse_clicked(bool checked)
         progress.setStyleSheet("QProgressBar {text-align: center; qproperty-format: \"\"}");
 
         // Performance test
-        QTime time;
+        QElapsedTimer time;
 
         // Set current model to prevent reseting heightmap cache
         m_currentModel = &m_programHeightmapModel;

--- a/src/frmmain_settings.cpp
+++ b/src/frmmain_settings.cpp
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
+#include <QCompleter>
 #include <QFileDialog>
 
 #include "frmmain.h"
@@ -393,7 +394,7 @@ void frmMain::applySettings()
     ui->grpOverriding->setVisible(m_settings->panelOverriding());
     ui->grpJog->setVisible(m_settings->panelJog());
 
-    ui->cboCommand->setAutoCompletion(m_settings->autoCompletion());
+    ui->cboCommand->setCompleter(m_settings->autoCompletion() ? new QCompleter(this) : nullptr);
 
     m_codeDrawer->setSimplify(m_settings->simplify());
     m_codeDrawer->setSimplifyPrecision(m_settings->simplifyPrecision());

--- a/src/frmmain_util.cpp
+++ b/src/frmmain_util.cpp
@@ -315,7 +315,7 @@ void frmMain::on_cmdFileOpen_clicked()
 
 void frmMain::loadFile(QList<QString> data)
 {
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     // Reset tables

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 */
 #include <QApplication>
 #include <QDebug>
-#include <QGLWidget>
 #include <QLocale>
 #include <QTranslator>
 #include <QFile>
@@ -51,10 +50,9 @@ int main(int argc, char *argv[])
     QFontDatabase::addApplicationFont(":/fonts/Ubuntu-R.ttf");
 #endif
 
-    QGLFormat glf = QGLFormat::defaultFormat();
-    glf.setSampleBuffers(true);
+    QSurfaceFormat glf = QSurfaceFormat::defaultFormat();
     glf.setSamples(8);
-    QGLFormat::setDefaultFormat(glf);
+    QSurfaceFormat::setDefaultFormat(glf);
 
 //    QLocale::setDefault(QLocale("es"));
 

--- a/src/tables/gcodetablemodel.cpp
+++ b/src/tables/gcodetablemodel.cpp
@@ -124,7 +124,7 @@ QVariant GCodeTableModel::headerData(int section, Qt::Orientation orientation, i
 
 Qt::ItemFlags GCodeTableModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return NULL;
+    if (!index.isValid()) return Qt::NoItemFlags;
     if (index.column() == 1) return QAbstractTableModel::flags(index) | Qt::ItemIsEditable;
     else return QAbstractTableModel::flags(index);
 }

--- a/src/tables/heightmaptablemodel.cpp
+++ b/src/tables/heightmaptablemodel.cpp
@@ -98,7 +98,7 @@ QVariant HeightMapTableModel::headerData(int section, Qt::Orientation orientatio
 
 Qt::ItemFlags HeightMapTableModel::flags(const QModelIndex &index) const
 {
-    if (!index.isValid()) return NULL;
+    if (!index.isValid()) return Qt::NoItemFlags;
     return QAbstractTableModel::flags(index) | Qt::ItemIsEditable;
 }
 

--- a/src/widgets/colorpicker.cpp
+++ b/src/widgets/colorpicker.cpp
@@ -11,7 +11,7 @@ ColorPicker::ColorPicker(QWidget *parent) :
 
     m_button->setText("...");
 
-    m_layout->setMargin(0);
+    m_layout->setContentsMargins(0, 0, 0, 0);
     m_layout->addWidget(m_frame, 1);
     m_layout->addWidget(m_button);
 

--- a/src/widgets/glwidget.cpp
+++ b/src/widgets/glwidget.cpp
@@ -493,15 +493,15 @@ void GLWidget::paintEvent(QPaintEvent *pe) {
     painter.drawText(QPoint(x, fm.height() * 3 + 10), m_pinState);
 
     QString str = QString(tr("Vertices: %1")).arg(vertices);
-    painter.drawText(QPoint(this->width() - fm.width(str) - 10, y + 30), str);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(str) - 10, y + 30), str);
     str = QString("FPS: %1").arg(m_fps);
-    painter.drawText(QPoint(this->width() - fm.width(str) - 10, y + 45), str);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(str) - 10, y + 45), str);
 
     str = m_spendTime.toString("hh:mm:ss") + " / " + m_estimatedTime.toString("hh:mm:ss");
-    painter.drawText(QPoint(this->width() - fm.width(str) - 10, y), str);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(str) - 10, y), str);
 
     str = m_bufferState;
-    painter.drawText(QPoint(this->width() - fm.width(str) - 10, y + 15), str);
+    painter.drawText(QPoint(this->width() - fm.horizontalAdvance(str) - 10, y + 15), str);
 
     m_frames++;
 
@@ -545,16 +545,16 @@ void GLWidget::mouseMoveEvent(QMouseEvent *event)
 
 void GLWidget::wheelEvent(QWheelEvent *we)
 {
-    if (m_zoom > 0.1 && we->delta() < 0) {
-        m_xPan -= ((double)we->pos().x() / width() - 0.5 + m_xPan) * (1 - 1 / ZOOMSTEP);
-        m_yPan += ((double)we->pos().y() / height() - 0.5 - m_yPan) * (1 - 1 / ZOOMSTEP);
+    if (m_zoom > 0.1 && we->angleDelta().y() < 0) {
+        m_xPan -= ((double)we->position().x() / width() - 0.5 + m_xPan) * (1 - 1 / ZOOMSTEP);
+        m_yPan += ((double)we->position().y() / height() - 0.5 - m_yPan) * (1 - 1 / ZOOMSTEP);
 
         m_zoom /= ZOOMSTEP;
     }
-    else if (m_zoom < 10 && we->delta() > 0)
+    else if (m_zoom < 10 && we->angleDelta().y() > 0)
     {
-        m_xPan -= ((double)we->pos().x() / width() - 0.5 + m_xPan) * (1 - ZOOMSTEP);
-        m_yPan += ((double)we->pos().y() / height() - 0.5 - m_yPan) * (1 - ZOOMSTEP);
+        m_xPan -= ((double)we->position().x() / width() - 0.5 + m_xPan) * (1 - ZOOMSTEP);
+        m_yPan += ((double)we->position().y() / height() - 0.5 - m_yPan) * (1 - ZOOMSTEP);
 
         m_zoom *= ZOOMSTEP;
     }

--- a/src/widgets/styledtoolbutton.cpp
+++ b/src/widgets/styledtoolbutton.cpp
@@ -42,7 +42,6 @@ void StyledToolButton::paintEvent(QPaintEvent *e)
     QPainter painter(this);
 
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setRenderHint(QPainter::HighQualityAntialiasing);
 
     // Highlight
     QPen highlightPen;

--- a/src/widgets/styledtoolbutton.h
+++ b/src/widgets/styledtoolbutton.h
@@ -12,6 +12,8 @@
 
 class StyledToolButton : public QToolButton
 {
+    Q_OBJECT
+
 public:
     explicit StyledToolButton(QWidget *parent = 0);
 


### PR DESCRIPTION
I tried porting Candle2 to Qt 6 and I noticed some pieces that are good to integrate even in Qt 5.x.
The PR is split into several patches for easier review and, optionally, merging just some of them. In case you are interested, the version that builds fully on Qt6 is available on my `qt6` branch.

I also left out porting QRegExp to QRegularExpression for easier review. Feel free to cherry-pick my commit on this from my qt6 branch.

Some porting hints from the Qt docs:
- https://doc.qt.io/archives/qt-5.15/qtime-obsolete.html#start
- https://doc.qt.io/archives/qt-5.15/qfontmetrics-obsolete.html#width
- https://doc.qt.io/archives/qt-5.15/qlayout-obsolete.html#setMargin
- https://doc.qt.io/archives/qt-5.15/qpainter.html#RenderHint-enum (removed flag has been ignored since 5.5 at least)
- https://doc.qt.io/archives/qt-5.15/qwheelevent-obsolete.html#pos

Note that adding Q_OBJECT to a class requires to re-run qmake (in order to generate the new MOC).